### PR TITLE
Add require event for autolabeler to support PRs from forks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,8 @@ name: Build & Release draft
 on:
   push: ~
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 jobs:


### PR DESCRIPTION
## Release drafter

pull_request_target event is required for autolabeler to support PRs from forks