### PR TITLE
feat(portfolio) retrieves the content of a project from the portfolio

### DIFF
--- a/components/blog/PostBody.module.css
+++ b/components/blog/PostBody.module.css
@@ -101,3 +101,12 @@
 .content [class~=has-text-align-center] {
   @apply text-center;
 }
+
+.content [class~=wp-block-gallery] [class~=blocks-gallery-grid] {
+  @apply grid gap-3;
+}
+
+
+.content [class~=wp-block-gallery][class~=columns-3] [class~=blocks-gallery-grid] {
+  @apply grid-cols-3;
+}

--- a/components/blog/PostBody.module.css
+++ b/components/blog/PostBody.module.css
@@ -82,3 +82,22 @@
     font-family: Monaco,Consolas,Andale Mono,DejaVu Sans Mono,monospace;
 }
 
+.content [class~=wp-block-columns] {
+  @apply flex;
+}
+
+.content [class~=is-vertically-aligned-center] {
+  @apply self-center;
+}
+
+.content [class~=wp-block-columns] [class~=wp-block-column]:first-child {
+  @apply mr-4;
+}
+
+.content [class~=button] {
+  @apply text-white;
+}
+
+.content [class~=has-text-align-center] {
+  @apply text-center;
+}

--- a/components/blog/PostBody.module.css
+++ b/components/blog/PostBody.module.css
@@ -83,7 +83,7 @@
 }
 
 .content [class~=wp-block-columns] {
-  @apply flex;
+  @apply block md:flex;
 }
 
 .content [class~=is-vertically-aligned-center] {
@@ -108,5 +108,5 @@
 
 
 .content [class~=wp-block-gallery][class~=columns-3] [class~=blocks-gallery-grid] {
-  @apply grid-cols-3;
+  @apply grid-cols-1 md:grid-cols-3;
 }

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -49,6 +49,7 @@ export async function getSingleProject(slug: string, preview: boolean = false) {
       id
       title
       slug
+      content
       featuredImage {
         node {
           sourceUrl

--- a/pages/portfolio/[support]/[slug].tsx
+++ b/pages/portfolio/[support]/[slug].tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import sanitize from 'sanitize-html';
 
+import PostBody from '@component/blog/PostBody';
 import ProjectItem from '@component/items/ProjectItem';
 import Layout from '@component/layouts/Layout';
 import SectionTitle from '@component/SectionTitle';
@@ -27,6 +28,7 @@ type Props = {
         };
       }>;
     };
+    content: string;
     detail: {
       excerpt: string;
       websiteLink: string;
@@ -141,6 +143,12 @@ export default function PortfolioDetail({ post, similarProjects }: Props) {
                 />
               </div>
             </div>
+
+            {post.content && (
+              <div className="my-8">
+                <PostBody content={post?.content || ''} />
+              </div>
+            )}
 
             <SectionTitle
               content={`Retrouvez des projets similaires développés avec ${post?.supports?.edges[0]?.node.name} qui pourrait correspondre à ${post.title}`}


### PR DESCRIPTION
Some projects have the details of the service and currently I was not retrieving the content of these.

We will use GraphQL to retrieve the `content` key and we will use the same principle as for the blog to display its content with the `<PostBody />` component