### PR TITLE
fix(comment): use `ID` instead of `Int` as parent type

### DIFF
--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -134,7 +134,7 @@ export async function submitNewComment(
 ) {
   const data = await fetchAPI(
     `mutation CREATE_COMMENT($id: Int, $authorEmail: String, $comment: String, $author: String${
-      parent ? ', $parent: Int' : ''
+      parent ? ', $parent: ID' : ''
     }) {
       createComment(input: {
         commentOn: $id, 


### PR DESCRIPTION
Upgrade the parent type since : https://github.com/wp-graphql/wp-graphql/pull/2328