### PR TITLE
fix(env): cleanup environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -8,15 +8,15 @@ MJ_APIKEY_PRIVATE=""
 # Used to configure the communication with WordPress
 BACKEND_URL="http://127.0.0.1:8000"
 WORDPRESS_API_URL=$BACKEND_URL/graphql
-NEXT_PUBLIC_PROTOCOL="https"
+
+# Used to determine the front URL
+NEXT_PUBLIC_PROTOCOL="http"
 VERCEL_URL="localhost:3000"
-NEXT_PUBLIC_FRONT_URL=$VERCEL_URL
+NEXT_PUBLIC_FRONT_DOMAIN=$VERCEL_URL
+NEXT_PUBLIC_FRONT_URL=$NEXT_PUBLIC_PROTOCOL://$NEXT_PUBLIC_FRONT_DOMAIN
 
 # Used by Slack to send a notification to the Slack channel
 SLACK_WEBHOOK_URL=""
 
-# Only required if you want to enable preview mode
-# WORDPRESS_AUTH_REFRESH_TOKEN=
-# WORDPRESS_PREVIEW_SECRET=
-
+# Used by Sentry to send errors to the Sentry dashboard
 SENTRY_DSN=

--- a/src/app/libs/route.ts
+++ b/src/app/libs/route.ts
@@ -39,7 +39,7 @@ export const getCanonicalUrl = (part: string = ''): string => {
 export const replaceBackendUrlContent = (content: string): string => {
   return content.replace(
     process.env.BACKEND_URL as string,
-    `https://${process.env.VERCEL_URL}`
+    process.env.NEXT_PUBLIC_FRONT_URL as string
   );
 };
 


### PR DESCRIPTION
Find a better way to handle public front URL and remove temporary WordPress preview URLs