### PR TITLE
fix(seo): use the real front url of the shop

### DIFF
--- a/src/app/libs/route.ts
+++ b/src/app/libs/route.ts
@@ -33,7 +33,7 @@ export const RouteLink = {
 };
 
 export const getCanonicalUrl = (part: string = ''): string => {
-  return `https://${process.env.VERCEL_URL}${part}`;
+  return `${process.env.NEXT_PUBLIC_FRONT_URL}${part}`;
 };
 
 export const replaceBackendUrlContent = (content: string): string => {


### PR DESCRIPTION
Vercel use the wrong front URL. We've fix the URL with the `NEXT_PUBLIC_FRONT_URL` environment variable