### PR TITLE
feat(ci): add Github Action for deployment based on tags and teleases

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,21 @@
+name: Production Tag Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    tags:        
+      - '*'
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
+  "github": {
+    "autoJobCancelation": true
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,9 @@
 {
   "git": {
     "deploymentEnabled": {
-      "main": false
+      "main": false,
+      "feat/*": false,
+      "fix/*": false
     }
   },
   "github": {


### PR DESCRIPTION
Currently, the site is automatically deployed whenever we push to a branch. However, we need to be able to deploy only when a new tag is in place on Git. To achieve this, we can use the Github Action principle.

We will follow the tutorial "How to Deploy Based on Tags or Releases on Vercel" to create a vercel.json file that tells Vercel not to deploy automatically. Then, we will create a Github Action based on the On Push Tag principle and deploy to Vercel using the tokens we have retrieved.

Additionally, we no longer want to deploy to every feature/fix branch of our project, but we can consider taking care of the deployment on the dev branch of our project.

With this approach, when a commit is pushed to the main branch (dev merged onto main), it will no longer invoke automatic deployment on Vercel. We retain the freedom to generate our release before it is deployed in production.