### PR TITLE
chore: replace Figma with Adobe XD for the Beurlay project.

### DIFF
--- a/app/content/portfolio/patisserie-beurlay.mdx
+++ b/app/content/portfolio/patisserie-beurlay.mdx
@@ -6,8 +6,8 @@ year: 2024
 summary: "Création d'un site e-commerce pour la Pâtisserie Beurlay avec une approche mobile first et une optimisation 100% Lighthouse. Site développé sur WordPress avec WooCommerce et Gutenberg."
 excerpt: "Refonte complète du site e-commerce de la Pâtisserie Beurlay avec une approche mobile first et une optimisation 100% Lighthouse. Développement sur WordPress avec WooCommerce, intégration de blocs Gutenberg sur mesure et création d'un back-office intuitif pour une gestion simplifiée."
 actions:
-  - Création des maquettes Figma mobile et desktop
-  - Intégration des maquettes Figma en mobile first
+  - Création des maquettes Adobe XD mobile et desktop
+  - Intégration des maquettes Adobe XD en mobile first
   - Création d'une cinquantaine de blocs sur mesure Gutenberg
   - Une vitrine WooCommerce très performante et rapide
   - Un back-office similaire à celui du front-office
@@ -35,7 +35,7 @@ La Pâtisserie Beurlay souhaitait moderniser sa présence en ligne avec un site 
 
 ## Approche et technologies
 
-Nous avons adopté une méthodologie mobile first dès la conception des maquettes sur Figma, garantissant ainsi une expérience utilisateur optimale sur smartphones et tablettes. Le site a été développé sur WordPress avec le framework Sage 10, permettant d'allier flexibilité et performances.
+Nous avons adopté une méthodologie mobile first dès la conception des maquettes sur Adobe XD, garantissant ainsi une expérience utilisateur optimale sur smartphones et tablettes. Le site a été développé sur WordPress avec le framework Sage 10, permettant d'allier flexibilité et performances.
 
 L'un des points forts du projet a été la création d'une cinquantaine de blocs Gutenberg sur mesure, offrant une grande liberté de composition tout en maintenant une cohérence visuelle parfaite. Cette approche full Gutenberg permet au client de gérer facilement le contenu de son site sans compromettre le design.
 


### PR DESCRIPTION
This pull request updates the project details for the Pâtisserie Beurlay portfolio entry, reflecting a change in the design tool used and ensuring consistency across descriptions. The most important changes involve replacing references to Figma with Adobe XD in both the project summary and the detailed methodology section.