### PR TITLE
feat: externalize GTM ID configuration

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -44,6 +44,7 @@ jobs:
           else
             echo "NEXT_PUBLIC_FRONT_URL=$STAGING_PUBLIC_FRONT_URL" >> $GITHUB_ENV
           fi
+          echo "NEXT_PUBLIC_GTM_ID=${{ secrets.GTM_ID }}" >> $GITHUB_ENV
       - name: Build Docker images
         uses: docker/bake-action@v5
         env:

--- a/app/(pages)/layout.tsx
+++ b/app/(pages)/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   }
   return (
     <html lang="fr">
-      <GoogleTagManager gtmId={process.env.GTM_ID!} />
+      <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID!} />
       <head />
       <body>
         <script

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -7,6 +7,7 @@ services:
       args:
         NEXT_PUBLIC_FRONT_URL: ${NEXT_PUBLIC_FRONT_URL}
         WORDPRESS_API_URL: ${WORDPRESS_API_URL}
+        NEXT_PUBLIC_GTM_ID: ${NEXT_PUBLIC_GTM_ID}
     environment:
       WORDPRESS_API_URL: ${WORDPRESS_API_URL}
     healthcheck:


### PR DESCRIPTION
## Summary
- Move GTM ID to environment variables for better configuration management
- Enable flexible GTM configuration between environments without rebuilding

## Changes
- Update layout component to use `NEXT_PUBLIC_GTM_ID` environment variable
- Configure GitHub Actions workflow to pass GTM ID as build argument
- Update Docker compose to include GTM ID build arg
- **Fix**: Add missing `NEXT_PUBLIC_GTM_ID` ARG in Dockerfile

## Configuration
The GTM ID secret needs to be added in GitHub repository settings:
- `GTM_ID`: The Google Tag Manager container ID (e.g., GTM-TJCPQT5X)

## Fix Applied
The initial deployment showed `undefined` because the Dockerfile was missing the `ARG NEXT_PUBLIC_GTM_ID` declaration, preventing the environment variable from being available during the Next.js build process.