### PR TITLE
fix: add missing NEXT_PUBLIC_GTM_ID build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --link . .
 ARG WORDPRESS_API_URL
 # https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser
 ARG NEXT_PUBLIC_FRONT_URL
+ARG NEXT_PUBLIC_GTM_ID
 
 RUN	pnpm install --frozen-lockfile --offline --prod && \
 	pnpm run build


### PR DESCRIPTION
## Summary
- Fix Docker build missing environment variable argument
- Resolves undefined GTM configuration in production

## Changes
- Add missing `NEXT_PUBLIC_GTM_ID` ARG in Dockerfile builder stage
- Ensures environment variable is available during Next.js build process

## Issue
The Docker build was not accepting the GTM environment variable, causing it to be undefined in the deployed application despite being correctly configured in the CI/CD pipeline.