### PR TITLE
fix: mitigate Next.js scanner attacks and stale hydration error

### DIFF
--- a/app/(pages)/portfolio/[slug]/page.tsx
+++ b/app/(pages)/portfolio/[slug]/page.tsx
@@ -19,6 +19,10 @@ export async function generateMetadata(props: Props) {
   const category =
     portfolioCategories[params.slug as keyof typeof portfolioCategories]
 
+  if (!category) {
+    return {}
+  }
+
   return {
     title: `${category.title} - Portfolio`,
     description: '',

--- a/app/content/blog/contact-form-7-champ-conditionnel.mdx
+++ b/app/content/blog/contact-form-7-champ-conditionnel.mdx
@@ -9,13 +9,7 @@ excerpt: "Découvrez Simple Conditional Fields, l'extension WordPress qui révol
 import MdxIntroduction from '../../components/ui/MdxIntroduction'
 import Image from 'next/image'
 
-<MdxIntroduction>
-  En tant que développeur WordPress, je me suis souvent retrouvé face à ce
-  problème récurrent : comment créer des formulaires de contact intelligents qui
-  s'adaptent aux réponses de l'utilisateur ? Contact Form 7 est fantastique pour
-  sa simplicité, mais dès qu'il s'agit d'ajouter de la logique conditionnelle,
-  c'est le parcours du combattant.
-</MdxIntroduction>
+<MdxIntroduction>En tant que développeur WordPress, je me suis souvent retrouvé face à ce problème récurrent&nbsp;: comment créer des formulaires de contact intelligents qui s'adaptent aux réponses de l'utilisateur&nbsp;? Contact Form 7 est fantastique pour sa simplicité, mais dès qu'il s'agit d'ajouter de la logique conditionnelle, c'est le parcours du combattant.</MdxIntroduction>
 
 J'ai testé de nombreuses solutions : syntaxe complexe à retenir, plugins premium aux prix prohibitifs, interfaces contre-intuitives... Rien ne me satisfaisait vraiment. C'est pourquoi j'ai décidé de développer **Simple Conditional Fields for Contact Form 7**.
 

--- a/app/libs/sentry-config.ts
+++ b/app/libs/sentry-config.ts
@@ -30,6 +30,17 @@ export const getSentryBaseConfig = (): Sentry.BrowserOptions => ({
     'fetch failed',
     'Load failed',
     'AbortError',
+    'Failed to parse body as FormData',
+    'no boundary found in multipart body',
+    'Unexpected end of form',
+    'Body exceeded 1 MB limit',
+    'Malformed part header',
+    'Malformed content type',
+    "Cannot read properties of null (reading 'arrayBuffer')",
+    'Unexpected non-whitespace character after JSON',
+    /Unexpected token .* is not valid JSON/,
+    'Connection closed',
+    /Failed to load chunk \/_next\/static\/chunks\//,
   ],
 
   denyUrls: [
@@ -41,6 +52,34 @@ export const getSentryBaseConfig = (): Sentry.BrowserOptions => ({
 
   beforeSend(event, hint) {
     const error = hint.originalException
+
+    if (event.request?.headers) {
+      const headers = event.request.headers as Record<string, string>
+      const headerKeys = Object.keys(headers).map((k) => k.toLowerCase())
+      if (headerKeys.includes('x-middleware-subrequest')) {
+        return null
+      }
+      const ipSpoofingHeaders = [
+        'true-client-ip',
+        'x-azure-clientip',
+        'x-azure-socketip',
+        'x-client-ip',
+        'x-originating-ip',
+        'x-forwared',
+        'x-host',
+      ]
+      const spoofingCount = ipSpoofingHeaders.filter((h) =>
+        headerKeys.includes(h)
+      ).length
+      if (spoofingCount >= 3) {
+        return null
+      }
+    }
+
+    const url = event.request?.url || ''
+    if (/\/RSC\/[a-z0-9]{8,}\.txt$/i.test(url)) {
+      return null
+    }
 
     if (error && typeof error === 'object' && 'message' in error) {
       const message = String(error.message).toLowerCase()


### PR DESCRIPTION
## Summary

- Drop attack-pattern events from Sentry telemetry (CVE-2025-29927 probes, FormData fuzzing on RSC endpoints, IP-spoofing header floods)
- Guard `/portfolio/[slug]` `generateMetadata` against unknown slugs — bots crawling inexistent slugs were crashing the route before `notFound()` could fire
- Inline `<MdxIntroduction>` in the `contact-form-7-champ-conditionnel` blog article to avoid the nested `<p><p>` hydration mismatch (same root cause as bd3a291)

## Context

Sentry showed ~280 events/14d on `inrage-fr` production, with strong signatures of an automated Next.js exploit scanner: `X-Middleware-Subrequest` headers (CVE-2025-29927), malformed multipart bodies on `/RSC/<random>.txt`, and stacks of spoofed IP headers. Pairing the SDK filters here with the Traefik `customRequestHeaders` middleware (deployed separately) neutralises both the noise and the attack surface.

The portfolio crash and blog hydration error were unrelated bugs surfaced during the same triage.